### PR TITLE
Switch to testing Temurin 8, 11, 17

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 # https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI
+name: CI
 
 on:
   push:
@@ -12,13 +12,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        distribution: [ 'temurin' ]
+        java: [ '8', '11', '17' ]
+
+    name: Java ${{ matrix.java }}
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up java
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+          distribution: ${{ matrix.distribution }}
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
Adopt JDK has been replacedby Temurin and won't be updated.